### PR TITLE
SEPolicy: Fix some baseband-related denials

### DIFF
--- a/sepolicy/system_app.te
+++ b/sepolicy/system_app.te
@@ -1,1 +1,2 @@
 allow system_app shell_data_file:dir search;
+allow system_app baseband_prop:file r_file_perms;

--- a/sepolicy/system_server.te
+++ b/sepolicy/system_server.te
@@ -4,3 +4,4 @@ allow system_server sensord_data_file:dir { search write };
 allow system_server sensord_data_file:dir { getattr setattr };
 allow system_server sensord_data_file:fifo_file rw_file_perms;
 allow system_server led_deamon_data_file:fifo_file rw_file_perms;
+allow system_server baseband_prop:file r_file_perms;

--- a/sepolicy/untrusted_app.te
+++ b/sepolicy/untrusted_app.te
@@ -1,1 +1,2 @@
 allow untrusted_app storage_stub_file:dir getattr;
+allow untrusted_app baseband_prop:file r_file_perms;

--- a/sepolicy/untrusted_app.te
+++ b/sepolicy/untrusted_app.te
@@ -1,2 +1,1 @@
 allow untrusted_app storage_stub_file:dir getattr;
-allow untrusted_app baseband_prop:file r_file_perms;

--- a/sepolicy/zygote.te
+++ b/sepolicy/zygote.te
@@ -1,0 +1,1 @@
+allow zygote baseband_prop:file r_file_perms;


### PR DESCRIPTION
This fixes apps (including settings) not being able to get the baseband value on LineageOS 14.1.